### PR TITLE
Add S3 backend infrastructure for Terraform state management - Create…

### DIFF
--- a/terraform-backend/README.md
+++ b/terraform-backend/README.md
@@ -1,0 +1,116 @@
+# Terraform Backend Setup
+
+This directory contains the Terraform configuration to create the S3 bucket and DynamoDB table required for storing Terraform state remotely.
+
+## Purpose
+
+This setup creates the backend infrastructure needed for:
+- S3 bucket for storing Terraform state files
+- DynamoDB table for state locking and consistency
+
+## Prerequisites
+
+1. AWS CLI configured with appropriate credentials
+2. Terraform installed (version >= 1.0)
+3. IAM permissions to create S3 bucket and DynamoDB table
+
+## Deployment Instructions
+
+### 1. Configure Variables
+
+Copy and edit the variables file:
+
+```bash
+cp terraform.tfvars.example terraform.tfvars
+```
+
+Edit `terraform.tfvars` with your specific values:
+
+```hcl
+aws_region        = "ap-southeast-2"
+state_bucket_name = "your-project-terraform-state-bucket"
+lock_table_name   = "terraform-state-locks"
+environment       = "shared"
+```
+
+**Important**: Choose a globally unique bucket name!
+
+### 2. Deploy Backend Infrastructure
+
+```bash
+# Initialize Terraform (local state for backend setup)
+terraform init
+
+# Plan the deployment
+terraform plan
+
+# Apply the configuration
+terraform apply
+```
+
+### 3. Note the Outputs
+
+After successful deployment, save the outputs:
+
+```bash
+terraform output
+```
+
+You'll need these values for configuring the main infrastructure.
+
+## Using the Backend
+
+Once the backend infrastructure is created, configure your main Terraform project to use it.
+
+### Method 1: Backend Config File
+
+Create a file named `backend.hcl` in your main terraform directory:
+
+```hcl
+bucket         = "your-terraform-state-bucket"
+key            = "terraform.tfstate"
+region         = "ap-southeast-2"
+dynamodb_table = "terraform-state-locks"
+encrypt        = true
+```
+
+Then initialize with:
+
+```bash
+terraform init -backend-config=backend.hcl
+```
+
+### Method 2: Command Line
+
+Initialize with backend configuration:
+
+```bash
+terraform init \
+  -backend-config="bucket=your-terraform-state-bucket" \
+  -backend-config="key=terraform.tfstate" \
+  -backend-config="region=ap-southeast-2" \
+  -backend-config="dynamodb_table=terraform-state-locks" \
+  -backend-config="encrypt=true"
+```
+
+## Resources Created
+
+- **S3 Bucket**: Stores Terraform state files with versioning enabled
+- **DynamoDB Table**: Provides state locking to prevent concurrent modifications
+
+## Security Features
+
+- S3 bucket versioning enabled
+- S3 bucket encryption (AES256)
+- Public access blocked on S3 bucket
+- DynamoDB table for state locking
+
+## Cleanup
+
+To destroy the backend infrastructure:
+
+```bash
+terraform destroy
+```
+
+**Warning**: Only destroy after migrating state back to local or ensuring no other projects are using this backend!

--- a/terraform-backend/main.tf
+++ b/terraform-backend/main.tf
@@ -1,0 +1,66 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+resource "aws_s3_bucket" "terraform_state" {
+  bucket = var.state_bucket_name
+
+  tags = {
+    Name        = "Terraform State Bucket"
+    Environment = var.environment
+    Purpose     = "terraform-state-storage"
+  }
+}
+
+resource "aws_s3_bucket_versioning" "terraform_state" {
+  bucket = aws_s3_bucket.terraform_state.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "terraform_state" {
+  bucket = aws_s3_bucket.terraform_state.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "terraform_state" {
+  bucket = aws_s3_bucket.terraform_state.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_dynamodb_table" "terraform_locks" {
+  name           = var.lock_table_name
+  billing_mode   = "PAY_PER_REQUEST"
+  hash_key       = "LockID"
+
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+
+  tags = {
+    Name        = "Terraform Lock Table"
+    Environment = var.environment
+    Purpose     = "terraform-state-locking"
+  }
+}

--- a/terraform-backend/outputs.tf
+++ b/terraform-backend/outputs.tf
@@ -1,0 +1,19 @@
+output "s3_bucket_name" {
+  description = "Name of the S3 bucket for Terraform state"
+  value       = aws_s3_bucket.terraform_state.bucket
+}
+
+output "s3_bucket_arn" {
+  description = "ARN of the S3 bucket for Terraform state"
+  value       = aws_s3_bucket.terraform_state.arn
+}
+
+output "dynamodb_table_name" {
+  description = "Name of the DynamoDB table for Terraform state locking"
+  value       = aws_dynamodb_table.terraform_locks.name
+}
+
+output "dynamodb_table_arn" {
+  description = "ARN of the DynamoDB table for Terraform state locking"
+  value       = aws_dynamodb_table.terraform_locks.arn
+}

--- a/terraform-backend/terraform.tfvars.example
+++ b/terraform-backend/terraform.tfvars.example
@@ -1,0 +1,4 @@
+aws_region        = "ap-southeast-2"
+state_bucket_name = "your-project-terraform-state-bucket"
+lock_table_name   = "terraform-state-locks"
+environment       = "shared"

--- a/terraform-backend/variables.tf
+++ b/terraform-backend/variables.tf
@@ -1,0 +1,22 @@
+variable "aws_region" {
+  description = "AWS region for resources"
+  type        = string
+  default     = "ap-southeast-2"
+}
+
+variable "state_bucket_name" {
+  description = "Name of the S3 bucket for Terraform state"
+  type        = string
+}
+
+variable "lock_table_name" {
+  description = "Name of the DynamoDB table for Terraform state locking"
+  type        = string
+  default     = "terraform-state-locks"
+}
+
+variable "environment" {
+  description = "Environment name"
+  type        = string
+  default     = "shared"
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -6,6 +6,15 @@ terraform {
       version = "~> 5.0"
     }
   }
+
+  backend "s3" {
+    # Configure via terraform init with backend-config flags or terraform.tfvars
+    # bucket         = "your-terraform-state-bucket"
+    # key            = "terraform.tfstate"
+    # region         = "ap-southeast-2"
+    # dynamodb_table = "terraform-state-locks"
+    # encrypt        = true
+  }
 }
 
 provider "aws" {


### PR DESCRIPTION
… terraform-backend module with S3 bucket and DynamoDB table - Enable versioning and encryption on S3 bucket - Configure DynamoDB table for state locking - Update main Terraform configuration to use S3 backend - Update documentation with backend setup instructions