### PR TITLE
Implement blue/green deployment infrastructure for ECS services

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -75,17 +75,26 @@ module "rds" {
 module "ecs" {
   source = "./modules/ecs"
 
-  project_name              = var.project_name
-  environment               = var.environment
-  vpc_id                    = module.networking.vpc_id
-  public_subnet_id          = module.networking.public_subnet_id
-  private_subnet_id         = module.networking.private_subnet_id
-  frontend_security_group_id = module.security.frontend_security_group_id
-  backend_security_group_id  = module.security.backend_security_group_id
-  alb_target_group_arn      = module.alb.target_group_arn
-  rds_endpoint              = module.rds.rds_endpoint
-  db_secret_arn             = module.rds.db_secret_arn
-  db_name                   = var.db_name
+  project_name                   = var.project_name
+  environment                    = var.environment
+  vpc_id                         = module.networking.vpc_id
+  public_subnet_id               = module.networking.public_subnet_id
+  private_subnet_id              = module.networking.private_subnet_id
+  frontend_security_group_id     = module.security.frontend_security_group_id
+  backend_security_group_id      = module.security.backend_security_group_id
+
+  # Blue/Green Target Group ARNs
+  frontend_blue_target_group_arn  = module.alb.frontend_blue_target_group_arn
+  frontend_green_target_group_arn = module.alb.frontend_green_target_group_arn
+  backend_blue_target_group_arn   = module.alb.backend_blue_target_group_arn
+  backend_green_target_group_arn  = module.alb.backend_green_target_group_arn
+
+  # Legacy for backward compatibility
+  alb_target_group_arn           = module.alb.target_group_arn
+
+  rds_endpoint                   = module.rds.rds_endpoint
+  db_secret_arn                  = module.rds.db_secret_arn
+  db_name                        = var.db_name
 
   tags = local.common_tags
 }

--- a/terraform/modules/alb/outputs.tf
+++ b/terraform/modules/alb/outputs.tf
@@ -13,12 +13,66 @@ output "alb_arn" {
   value       = aws_lb.main.arn
 }
 
+output "listener_arn" {
+  description = "ARN of the HTTP listener"
+  value       = aws_lb_listener.frontend_http.arn
+}
+
+# Frontend Target Groups
+output "frontend_blue_target_group_arn" {
+  description = "ARN of the frontend blue target group"
+  value       = aws_lb_target_group.frontend_blue.arn
+}
+
+output "frontend_green_target_group_arn" {
+  description = "ARN of the frontend green target group"
+  value       = aws_lb_target_group.frontend_green.arn
+}
+
+output "frontend_blue_target_group_name" {
+  description = "Name of the frontend blue target group"
+  value       = aws_lb_target_group.frontend_blue.name
+}
+
+output "frontend_green_target_group_name" {
+  description = "Name of the frontend green target group"
+  value       = aws_lb_target_group.frontend_green.name
+}
+
+# Backend Target Groups
+output "backend_blue_target_group_arn" {
+  description = "ARN of the backend blue target group"
+  value       = aws_lb_target_group.backend_blue.arn
+}
+
+output "backend_green_target_group_arn" {
+  description = "ARN of the backend green target group"
+  value       = aws_lb_target_group.backend_green.arn
+}
+
+output "backend_blue_target_group_name" {
+  description = "Name of the backend blue target group"
+  value       = aws_lb_target_group.backend_blue.name
+}
+
+output "backend_green_target_group_name" {
+  description = "Name of the backend green target group"
+  value       = aws_lb_target_group.backend_green.name
+}
+
+# Listener Rule ARN for backend
+output "backend_listener_rule_arn" {
+  description = "ARN of the backend listener rule"
+  value       = aws_lb_listener_rule.backend_api.arn
+}
+
+# Legacy outputs for backward compatibility (using blue as active initially)
 output "target_group_arn" {
-  description = "ARN of the target group"
-  value       = aws_lb_target_group.frontend.arn
+  description = "ARN of the active target group (blue initially)"
+  value       = aws_lb_target_group.frontend_blue.arn
 }
 
 output "target_group_name" {
-  description = "Name of the target group"
-  value       = aws_lb_target_group.frontend.name
+  description = "Name of the active target group (blue initially)"
+  value       = aws_lb_target_group.frontend_blue.name
 }

--- a/terraform/modules/ecs/outputs.tf
+++ b/terraform/modules/ecs/outputs.tf
@@ -13,14 +13,36 @@ output "cluster_arn" {
   value       = aws_ecs_cluster.main.arn
 }
 
+# Blue/Green Service Names
+output "frontend_blue_service_name" {
+  description = "Name of the frontend blue ECS service"
+  value       = aws_ecs_service.frontend_blue.name
+}
+
+output "frontend_green_service_name" {
+  description = "Name of the frontend green ECS service"
+  value       = aws_ecs_service.frontend_green.name
+}
+
+output "backend_blue_service_name" {
+  description = "Name of the backend blue ECS service"
+  value       = aws_ecs_service.backend_blue.name
+}
+
+output "backend_green_service_name" {
+  description = "Name of the backend green ECS service"
+  value       = aws_ecs_service.backend_green.name
+}
+
+# Legacy outputs for backward compatibility
 output "frontend_service_name" {
-  description = "Name of the frontend ECS service"
-  value       = aws_ecs_service.frontend.name
+  description = "Name of the frontend ECS service (blue active by default)"
+  value       = aws_ecs_service.frontend_blue.name
 }
 
 output "backend_service_name" {
-  description = "Name of the backend ECS service"
-  value       = aws_ecs_service.backend.name
+  description = "Name of the backend ECS service (blue active by default)"
+  value       = aws_ecs_service.backend_blue.name
 }
 
 output "frontend_task_definition_arn" {

--- a/terraform/modules/ecs/variables.tf
+++ b/terraform/modules/ecs/variables.tf
@@ -33,9 +33,33 @@ variable "backend_security_group_id" {
   type        = string
 }
 
-variable "alb_target_group_arn" {
-  description = "ARN of the ALB target group"
+# Blue/Green Target Group ARNs for Frontend
+variable "frontend_blue_target_group_arn" {
+  description = "ARN of the frontend blue target group"
   type        = string
+}
+
+variable "frontend_green_target_group_arn" {
+  description = "ARN of the frontend green target group"
+  type        = string
+}
+
+# Blue/Green Target Group ARNs for Backend
+variable "backend_blue_target_group_arn" {
+  description = "ARN of the backend blue target group"
+  type        = string
+}
+
+variable "backend_green_target_group_arn" {
+  description = "ARN of the backend green target group"
+  type        = string
+}
+
+# Legacy variable for backward compatibility
+variable "alb_target_group_arn" {
+  description = "ARN of the ALB target group (deprecated - use specific blue/green variants)"
+  type        = string
+  default     = ""
 }
 
 variable "rds_endpoint" {


### PR DESCRIPTION
Update ALB module to support dual target groups (blue/green) for frontend and backend.

Create separate ECS services for blue and green environments.

Add outputs for blue/green target group ARNs and service names.

Wire blue/green target group ARNs through main.tf to the ECS module.

Maintain backward compatibility with legacy configurations.

Enable zero-downtime deployments with instant rollback capability.